### PR TITLE
Build/Fetch Mesos 0.24.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ script:
   - make mesos-0.23.0 
   - make mesos-0.23.1 
   - make mesos-0.24.0
+  - make mesos-0.24.1
   - make autoconf
   - make isolator-0.23.0 
   - make isolator-0.23.1

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # MESOS_VERSIONS is a list of space, separated versions of mesos that 
 # will be built.
-MESOS_VERSIONS := 0.23.0 0.23.1 0.24.0
+MESOS_VERSIONS := 0.23.0 0.23.1 0.24.0 0.24.1
 
 # ISO_VERSIONS is either equal to or a subset of the MESOS_VERSIONS
 # list. The versions in this list are the versions of Mesos against 


### PR DESCRIPTION
This patch introduces support for fetching or building Mesos 0.24.1. This patch does _not_ include the necessary changes required to get the Isolator module working with >=0.24.x.

@dvonthenen, you should clean up your PR by first rebasing it on `master` after this PR is merged and then consolidate your commits into a single commit. One commit per PR is much cleaner.
