### PR TITLE
Add support for 0.27.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,11 +11,13 @@ script:
   - make mesos-0.24.1
   - make mesos-0.25.0
   - make mesos-0.26.0
+  - make mesos-0.27.0
   - make autoconf
   - make isolator-0.23.1
   - make isolator-0.24.1
   - make isolator-0.25.0
   - make isolator-0.26.0
+  - make isolator-0.27.0
   - make bintray
 
 addons:

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,11 @@
 # MESOS_VERSIONS is a list of space, separated versions of mesos that
 # will be built.
-MESOS_VERSIONS := 0.23.1 0.24.1 0.25.0 0.26.0
+MESOS_VERSIONS := 0.23.1 0.24.1 0.25.0 0.26.0 0.27.0
 
 # ISO_VERSIONS is either equal to or a subset of the MESOS_VERSIONS
 # list. The versions in this list are the versions of Mesos against
 # which to build the isolator module.
-ISO_VERSIONS := 0.23.1 0.24.1 0.25.0 0.26.0
+ISO_VERSIONS := 0.23.1 0.24.1 0.25.0 0.26.0 0.27.0
 
 ########################################################################
 ##                             MAKEFLAGS                              ##

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repo contains the `Docker Volume Driver Isolator Module` for Mesos.  The pu
 
 The module leverages [dvdcli](https://github.com/clintonskitson/dvdcli) to enable any existing `Docker Volume Drivers` to be used **without** the Docker containerizer.  All Volume Drivers that work with `Docker`, **will also** work with `dvdcli` and thus this Isolator Module.
 
-Currently it targets Mesos 0.23.1, 0.24.1, 0.25.0, and 0.26.0.
+Currently it targets Mesos 0.23.1, 0.24.1, 0.25.0, 0.26.0, and 0.27.0.
 
 Project Summary
 -------------------

--- a/isolator/isolator/docker_volume_driver_isolator.hpp
+++ b/isolator/isolator/docker_volume_driver_isolator.hpp
@@ -33,11 +33,7 @@
 #include <stout/try.hpp>
 
 #include <slave/flags.hpp>
-#if MESOS_VERSION_INT != 0 && MESOS_VERSION_INT < 0240
 #include <mesos/slave/isolator.hpp>
-#else
-#include <slave/containerizer/isolator.hpp>
-#endif
 
 #include "interface.hpp"
 using namespace emccode::isolator::mount;
@@ -97,8 +93,6 @@ public:
   //     VOL_NAME_ENV_VAR_NAME is defined below
   //     This is volume name, not ID.
   //     Warning, name collisions on name can be treacherous.
-  //     For now a simple string value is presumed, will need to enhance to
-  //     support a JSON array to allow multiple volume mounts per task.
   // 2. get desired volume driver (volumedriver=) from ENVIRONMENT from task in ExecutorInfo
   //     VOL_DRIVER_ENV_VAR_NAME is defined below
   // 3. Check for other pre-existing users of the mount.
@@ -114,12 +108,16 @@ public:
     const std::string& directory,
     const Option<std::string>& rootfs,
     const Option<std::string>& user);
-#else
+#elif MESOS_VERSION_INT != 0 && MESOS_VERSION_INT < 0270
   virtual process::Future<Option<ContainerPrepareInfo>> prepare(
     const ContainerID& containerId,
     const ExecutorInfo& executorInfo,
     const std::string& directory,
     const Option<std::string>& user);
+#else
+  virtual process::Future<Option<ContainerLaunchInfo>> prepare(
+    const ContainerID& containerId,
+    const ContainerConfig& containerConfig);
 #endif
 
   // Nothing will be done at task start
@@ -135,6 +133,7 @@ public:
   virtual process::Future<ContainerLimitation> watch(
     const ContainerID& containerId);
 #endif
+
   // no-op, nothing enforced
   virtual process::Future<Nothing> update(
     const ContainerID& containerId,


### PR DESCRIPTION
Resolves issue 43. Adds support for Mesos 0.27.0. Tested 0.23.1, 0.25.0, and 0.27.0.

Its all pretty standard, but the only minor exception is removing the ifdefs and only having this line. It turns out this exists in all versions of mesos in the include directory.
 `#include <mesos/slave/isolator.hpp>`

This only exists in the src dir and we probably shouldn't be using this directly even though its an exact copy.
`-#include <slave/containerizer/isolator.hpp>`
