### PR TITLE
Changes so that the isolator builds against 0.28.0.

### DIFF
--- a/Dockerfile-mesos-modules-dev
+++ b/Dockerfile-mesos-modules-dev
@@ -1,4 +1,4 @@
-FROM ubuntu-upstart:14.04
+FROM ubuntu:14.04
 MAINTAINER Mesosphere <support@mesosphere.io>
 
 # Install Dependencies
@@ -12,7 +12,7 @@ RUN apt-get -qy install \
   build-essential                         \
   autoconf                                \
   automake                                \
-  cmake=3.2.2-2ubuntu2~ubuntu14.04.1~ppa1 \
+  cmake=3.2.2-2~ubuntu14.04.1~ppa1        \
   ca-certificates                         \
   gdb                                     \
   wget                                    \
@@ -49,7 +49,7 @@ WORKDIR /mesos
 
 # Clone Mesos (master branch)
 RUN git clone https://github.com/apache/mesos.git /mesos
-RUN git checkout 864fe8eabd4a83b78ce9140c501908ee3cb90beb
+RUN git checkout 961edbd82e691a619a4c171a7aadc9c32957fa73
 RUN git log -n 1
 
 # Bootstrap

--- a/Makefile
+++ b/Makefile
@@ -794,8 +794,7 @@ isolator-$1-configure: $$(ISO_MAKEFILE_$1)
 $$(ISO_MAKEFILE_$1): CXXFLAGS=-I$$(GLOG_OPT_DIR)/include \
 													-I$$(PICOJSON_OPT_DIR)/include \
 													-I$$(BOOST_OPT_DIR) \
-													-I$$(PBUF_OPT_DIR)/include \
-													-DMESOS_VERSION_INT=$$(subst .,,$1)
+													-I$$(PBUF_OPT_DIR)/include
 $$(ISO_MAKEFILE_$1): $$(ISO_CONFIGURE_$1) $$(ISO_DEPS_$1)
 	mkdir -p $$(@D) && cd $$(@D) && \
 		env CXXFLAGS="$$(CXXFLAGS)" \

--- a/isolator/configure.ac
+++ b/isolator/configure.ac
@@ -181,7 +181,7 @@ if test -z "$MESOS_VERSION_INT"; then
   else
     MESOS_VERSION_FILE="$mesos_build_dir/include/mesos/version.hpp"
   fi
-  MESOS_VERSION_INT=`grep -e '#define MESOS_VERSION ' $MESOS_VERSION_FILE | awk '{print $3}' | tr -d .\"`
+  MESOS_VERSION_INT=`grep -e '#define MESOS_VERSION ' $MESOS_VERSION_FILE | awk '{print $3}' | tr -d .\" | awk '{x=$0+0;print x}'`
   CFLAGS="$CFLAGS -DMESOS_VERSION_INT=$MESOS_VERSION_INT"
   CXXFLAGS="$CXXFLAGS -DMESOS_VERSION_INT=$MESOS_VERSION_INT"
 fi

--- a/isolator/isolator/docker_volume_driver_isolator.cpp
+++ b/isolator/isolator/docker_volume_driver_isolator.cpp
@@ -51,7 +51,7 @@ using std::array;
 using namespace mesos;
 using namespace mesos::slave;
 
-#if MESOS_VERSION_INT != 0 && MESOS_VERSION_INT < 0240
+#if MESOS_VERSION_INT != 0 && MESOS_VERSION_INT < 240
 using mesos::slave::ExecutorRunState;
 using mesos::slave::IsolatorProcess;
 using mesos::slave::Limitation;
@@ -124,7 +124,7 @@ Try<Isolator*> DockerVolumeDriverIsolator::create(
                                  DVDI_MOUNTLIST_FILENAME);
   LOG(INFO) << "using " << mountPbFilename;
 
-#if MESOS_VERSION_INT != 0 && MESOS_VERSION_INT < 0240
+#if MESOS_VERSION_INT != 0 && MESOS_VERSION_INT < 240
   process::Owned<IsolatorProcess> process(
       new DockerVolumeDriverIsolator(parameters));
 
@@ -140,7 +140,7 @@ DockerVolumeDriverIsolator::~DockerVolumeDriverIsolator()
   google::protobuf::ShutdownProtobufLibrary();
 }
 
-#if MESOS_VERSION_INT != 0 && MESOS_VERSION_INT < 0240
+#if MESOS_VERSION_INT != 0 && MESOS_VERSION_INT < 240
 Future<Nothing> DockerVolumeDriverIsolator::recover(
     const list<ExecutorRunState>& states,
     const hashset<ContainerID>& orphans)
@@ -257,7 +257,7 @@ Future<Nothing> DockerVolumeDriverIsolator::recover(
     legacyMounts.put(getExternalMountId(*(mount.get())), mount);
   }
 
-#if MESOS_VERSION_INT != 0 && MESOS_VERSION_INT < 0240
+#if MESOS_VERSION_INT != 0 && MESOS_VERSION_INT < 240
   foreach (const ExecutorRunState& state, states) {
 
     if (originalContainerMounts.contains(state.id.value())) {
@@ -348,7 +348,7 @@ bool DockerVolumeDriverIsolator::unmount(
               << VOL_DRIVER_CMD_OPTION << em.volumedriver() << " "
               << VOL_NAME_CMD_OPTION << em.volumename();
 
-#if MESOS_VERSION_INT != 0 && MESOS_VERSION_INT < 0240
+#if MESOS_VERSION_INT != 0 && MESOS_VERSION_INT < 240
     std::ostringstream cmdOut;
     Try<int> retcode = os::shell(&cmdOut, "%s %s%s %s%s",
       DVDCLI_UNMOUNT_CMD,
@@ -372,7 +372,7 @@ bool DockerVolumeDriverIsolator::unmount(
                    << "manually unmounted previously "
                    << retcode.error();
     } else {
-#if MESOS_VERSION_INT != 0 && MESOS_VERSION_INT < 0240
+#if MESOS_VERSION_INT != 0 && MESOS_VERSION_INT < 240
       LOG(INFO) << DVDCLI_UNMOUNT_CMD << " returned " << retcode.get() << ", "
                 << cmdOut.str();
 #else
@@ -408,7 +408,7 @@ string DockerVolumeDriverIsolator::mount(
               << VOL_NAME_CMD_OPTION << em.volumename() << " "
               << em.options();
 
-#if MESOS_VERSION_INT != 0 && MESOS_VERSION_INT < 0240
+#if MESOS_VERSION_INT != 0 && MESOS_VERSION_INT < 240
     std::ostringstream cmdOut;
     Try<int> retcode = os::shell(&cmdOut, "%s %s%s %s%s %s",
       DVDCLI_MOUNT_CMD,
@@ -432,7 +432,7 @@ string DockerVolumeDriverIsolator::mount(
                  << callerLabelForLogging
                  << retcode.error();
     } else {
-#if MESOS_VERSION_INT != 0 && MESOS_VERSION_INT < 0240
+#if MESOS_VERSION_INT != 0 && MESOS_VERSION_INT < 240
       if (retcode.get() != 0) {
         LOG(ERROR) << DVDCLI_MOUNT_CMD << " returned errorcode "
                    << retcode.get();
@@ -537,14 +537,14 @@ Failure DockerVolumeDriverIsolator::revertMountlist(
 // there are any problems parsing or mounting even one
 // mount, we want to exit with an error and no new
 // mounted volumes. Goal: make all mounts or none.
-#if MESOS_VERSION_INT != 0 && MESOS_VERSION_INT < 0240
+#if MESOS_VERSION_INT != 0 && MESOS_VERSION_INT < 240
 Future<Option<CommandInfo>> DockerVolumeDriverIsolator::prepare(
   const ContainerID& containerId,
   const ExecutorInfo& executorInfo,
   const string& directory,
   const Option<string>& rootfs,
   const Option<string>& user)
-#elif MESOS_VERSION_INT != 0 && MESOS_VERSION_INT < 0270
+#elif MESOS_VERSION_INT != 0 && MESOS_VERSION_INT < 270
 Future<Option<ContainerPrepareInfo>> DockerVolumeDriverIsolator::prepare(
   const ContainerID& containerId,
   const ExecutorInfo& executorInfo,
@@ -563,7 +563,7 @@ Future<Option<ContainerLaunchInfo>> DockerVolumeDriverIsolator::prepare(
     return Failure("Container has already been prepared");
   }
 
-#if MESOS_VERSION_INT != 0 && MESOS_VERSION_INT >= 0270
+#if MESOS_VERSION_INT != 0 && MESOS_VERSION_INT >= 270
   const ExecutorInfo& executorInfo = containerConfig.executorinfo();
 #endif
 
@@ -575,11 +575,11 @@ Future<Option<ContainerLaunchInfo>> DockerVolumeDriverIsolator::prepare(
     return None();
   }
 
-#if MESOS_VERSION_INT != 0 && MESOS_VERSION_INT < 0240
+#if MESOS_VERSION_INT != 0 && MESOS_VERSION_INT < 240
   list<string> commands;
-#elif MESOS_VERSION_INT != 0 && MESOS_VERSION_INT < 0250
+#elif MESOS_VERSION_INT != 0 && MESOS_VERSION_INT < 250
   ContainerPrepareInfo prepareInfo;
-#elif MESOS_VERSION_INT != 0 && MESOS_VERSION_INT < 0270
+#elif MESOS_VERSION_INT != 0 && MESOS_VERSION_INT < 270
   ContainerPrepareInfo prepareInfo;
   prepareInfo.set_namespaces(CLONE_NEWNS);
 #else
@@ -805,7 +805,7 @@ Future<Option<ContainerLaunchInfo>> DockerVolumeDriverIsolator::prepare(
     LOG(INFO) << "queueing mount -n --rbind " << mountPoint
               << " " << containerPath;
 
-#if MESOS_VERSION_INT != 0 && MESOS_VERSION_INT < 0240
+#if MESOS_VERSION_INT != 0 && MESOS_VERSION_INT < 240
     // -n means don't write to /etc/mtab
     commands.push_back(
             "mount -n --rbind " + mountPoint + " " + containerPath);
@@ -824,7 +824,7 @@ Future<Option<ContainerLaunchInfo>> DockerVolumeDriverIsolator::prepare(
   mesos::internal::slave::state::checkpoint(mountPbFilename,
     inUseMountsProtobuf);
 
-#if MESOS_VERSION_INT != 0 && MESOS_VERSION_INT < 0240
+#if MESOS_VERSION_INT != 0 && MESOS_VERSION_INT < 240
   CommandInfo command;
   command.set_value(strings::join(" && ", commands));
 
@@ -834,7 +834,7 @@ Future<Option<ContainerLaunchInfo>> DockerVolumeDriverIsolator::prepare(
 #endif
 }
 
-#if MESOS_VERSION_INT != 0 && MESOS_VERSION_INT < 0240
+#if MESOS_VERSION_INT != 0 && MESOS_VERSION_INT < 240
 Future<Limitation> DockerVolumeDriverIsolator::watch(
     const ContainerID& containerId)
 {

--- a/isolator/isolator/docker_volume_driver_isolator.hpp
+++ b/isolator/isolator/docker_volume_driver_isolator.hpp
@@ -60,7 +60,7 @@ static constexpr char DVDI_MOUNTLIST_FILENAME[]   = "dvdimounts.pb";
 static constexpr char DVDI_WORKDIR_PARAM_NAME[]   = "work_dir";
 static constexpr char DEFAULT_WORKING_DIR[]       = "/tmp/mesos";
 
-#if MESOS_VERSION_INT != 0 && MESOS_VERSION_INT < 0240
+#if MESOS_VERSION_INT != 0 && MESOS_VERSION_INT < 240
 class DockerVolumeDriverIsolator: public mesos::slave::IsolatorProcess
 #else
 class DockerVolumeDriverIsolator: public mesos::slave::Isolator
@@ -75,7 +75,7 @@ public:
   // to keep running if a slave process goes down, AND
   // allows the slave process to reconnect with already running
   // slaves when it restarts
-#if MESOS_VERSION_INT != 0 && MESOS_VERSION_INT < 0240
+#if MESOS_VERSION_INT != 0 && MESOS_VERSION_INT < 240
   virtual process::Future<Nothing> recover(
     const std::list<mesos::slave::ExecutorRunState>& states,
     const hashset<ContainerID>& orphans);
@@ -101,14 +101,14 @@ public:
   //    this call is synchronous, and returns 0 if success
   //    actual call is defined below in DVDCLI_MOUNT_CMD
   // 5. Add entry to hashmap that contains root mountpath indexed by ContainerId
-#if MESOS_VERSION_INT != 0 && MESOS_VERSION_INT < 0240
+#if MESOS_VERSION_INT != 0 && MESOS_VERSION_INT < 240
   virtual process::Future<Option<CommandInfo>> prepare(
     const ContainerID& containerId,
     const ExecutorInfo& executorInfo,
     const std::string& directory,
     const Option<std::string>& rootfs,
     const Option<std::string>& user);
-#elif MESOS_VERSION_INT != 0 && MESOS_VERSION_INT < 0270
+#elif MESOS_VERSION_INT != 0 && MESOS_VERSION_INT < 270
   virtual process::Future<Option<ContainerPrepareInfo>> prepare(
     const ContainerID& containerId,
     const ExecutorInfo& executorInfo,
@@ -126,7 +126,7 @@ public:
       pid_t pid);
 
   // no-op, mount occurs at prepare
-#if MESOS_VERSION_INT != 0 && MESOS_VERSION_INT < 0240
+#if MESOS_VERSION_INT != 0 && MESOS_VERSION_INT < 240
   virtual process::Future<mesos::slave::Limitation> watch(
     const ContainerID& containerId);
 #else


### PR DESCRIPTION
I have not verified that 0.28.0 actually works which is why the 0.28.0 is not enabled in the CI build yet. Will also need to create the mesos 0.28.0 cache to avoid the super long CI build times.
