### PR TITLE
Adds 0.28.0 support. Will need to test.

### DIFF
--- a/isolator/isolator/docker_volume_driver_isolator.cpp
+++ b/isolator/isolator/docker_volume_driver_isolator.cpp
@@ -563,8 +563,10 @@ Future<Option<ContainerLaunchInfo>> DockerVolumeDriverIsolator::prepare(
     return Failure("Container has already been prepared");
   }
 
-#if MESOS_VERSION_INT != 0 && MESOS_VERSION_INT >= 270
+#if MESOS_VERSION_INT != 0 && MESOS_VERSION_INT >= 280
   const ExecutorInfo& executorInfo = containerConfig.executor_info();
+#elif MESOS_VERSION_INT != 0 && MESOS_VERSION_INT >= 270
+  const ExecutorInfo& executorInfo = containerConfig.executorinfo();
 #endif
 
   // Get things we need from task's environment in ExecutoInfo.

--- a/isolator/isolator/docker_volume_driver_isolator.cpp
+++ b/isolator/isolator/docker_volume_driver_isolator.cpp
@@ -564,7 +564,7 @@ Future<Option<ContainerLaunchInfo>> DockerVolumeDriverIsolator::prepare(
   }
 
 #if MESOS_VERSION_INT != 0 && MESOS_VERSION_INT >= 270
-  const ExecutorInfo& executorInfo = containerConfig.executorinfo();
+  const ExecutorInfo& executorInfo = containerConfig.executor_info();
 #endif
 
   // Get things we need from task's environment in ExecutoInfo.


### PR DESCRIPTION
In 0.28.0, they renamed one of the protobuf parameters, but left the old parameter name for backwards compatibility. They have a note in the code not to use the old value because it is deprecated and the old parameter name will be removed in 0.29.0.
