### PR TITLE
Feature to add user-defined specification for the placement of DVDCLI

### DIFF
--- a/isolator/isolator/docker_volume_driver_isolator.cpp
+++ b/isolator/isolator/docker_volume_driver_isolator.cpp
@@ -79,7 +79,6 @@ const char DockerVolumeDriverIsolator::prohibitedchars[NUM_PROHIBITED]  =
 string DockerVolumeDriverIsolator::mountPbFilename;
 string DockerVolumeDriverIsolator::mesosWorkingDir;
 
-
 DockerVolumeDriverIsolator::DockerVolumeDriverIsolator(
   const Parameters& _parameters)
   : parameters(_parameters)
@@ -343,22 +342,31 @@ bool DockerVolumeDriverIsolator::unmount(
             << " is being unmounted on "
             << callerLabelForLogging;
 
+  if (!os::exists(em.dvdcli_path())) {
+    LOG(ERROR) << "The DVDCLI binary doesn't exist at the specified path "
+               << em.dvdcli_path();
+    return false;
+  }
+
   if (system(NULL)) { // Is a command processor available?
 
-    LOG(INFO) << "Invoking " << DVDCLI_UNMOUNT_CMD << " "
+    LOG(INFO) << "Invoking " << em.dvdcli_path()
+              << " " << DVDCLI_UNMOUNT_CMD << " "
               << VOL_DRIVER_CMD_OPTION << em.volumedriver() << " "
               << VOL_NAME_CMD_OPTION << em.volumename();
 
 #if MESOS_VERSION_INT != 0 && MESOS_VERSION_INT < 240
     std::ostringstream cmdOut;
-    Try<int> retcode = os::shell(&cmdOut, "%s %s%s %s%s",
+    Try<int> retcode = os::shell(&cmdOut, "%s %s %s%s %s%s",
+      em.dvdcli_path().c_str(),
       DVDCLI_UNMOUNT_CMD,
       VOL_DRIVER_CMD_OPTION,
       em.volumedriver().c_str(),
       VOL_NAME_CMD_OPTION,
       em.volumename().c_str());
 #else
-    Try<string> retcode = os::shell("%s %s%s %s%s ",
+    Try<string> retcode = os::shell("%s %s %s%s %s%s ",
+      em.dvdcli_path().c_str(),
       DVDCLI_UNMOUNT_CMD,
       VOL_DRIVER_CMD_OPTION,
       em.volumedriver().c_str(),
@@ -367,17 +375,18 @@ bool DockerVolumeDriverIsolator::unmount(
 #endif
 
     if (retcode.isError()) {
-      LOG(WARNING) << DVDCLI_UNMOUNT_CMD << " failed to execute on "
-                   << callerLabelForLogging
+      LOG(WARNING) << em.dvdcli_path() << " " << DVDCLI_UNMOUNT_CMD
+                   << " failed to execute on " << callerLabelForLogging
                    << ", continuing on the assumption this volume was "
                    << "manually unmounted previously "
                    << retcode.error();
     } else {
 #if MESOS_VERSION_INT != 0 && MESOS_VERSION_INT < 240
-      LOG(INFO) << DVDCLI_UNMOUNT_CMD << " returned " << retcode.get() << ", "
-                << cmdOut.str();
+      LOG(INFO) << em.dvdcli_path() << " " << DVDCLI_UNMOUNT_CMD
+        << " returned " << retcode.get() << ", " << cmdOut.str();
 #else
-      LOG(INFO) << DVDCLI_UNMOUNT_CMD << " returned " << retcode.get();
+      LOG(INFO) << em.dvdcli_path() << " " << DVDCLI_UNMOUNT_CMD
+        << " returned " << retcode.get();
 #endif
     }
   } else {
@@ -417,20 +426,26 @@ string DockerVolumeDriverIsolator::mount(
             << " is being mounted on "
             << callerLabelForLogging;
 
-  const string volumeDriver = em.volumedriver();
-  const string volumeName = em.volumename();
+  if (!os::exists(em.dvdcli_path())) {
+    LOG(ERROR) << "The DVDCLI binary doesn't exist at the specified path "
+               << em.dvdcli_path();
+    return false;
+  }
+
   string mountpoint; // Return value init'd to empty.
   const string options = formatOptions(em.options());
 
   if (system(NULL)) { // Is a command processor available?
-    LOG(INFO) << "Invoking " << DVDCLI_MOUNT_CMD << " "
+    LOG(INFO) << "Invoking " << em.dvdcli_path()
+              << " " << DVDCLI_MOUNT_CMD << " "
               << VOL_DRIVER_CMD_OPTION << em.volumedriver() << " "
               << VOL_NAME_CMD_OPTION << em.volumename() << " "
               << options;
 
 #if MESOS_VERSION_INT != 0 && MESOS_VERSION_INT < 240
     std::ostringstream cmdOut;
-    Try<int> retcode = os::shell(&cmdOut, "%s %s%s %s%s %s",
+    Try<int> retcode = os::shell(&cmdOut, "%s %s %s%s %s%s %s",
+      em.dvdcli_path().c_str(),
       DVDCLI_MOUNT_CMD,
       VOL_DRIVER_CMD_OPTION,
       em.volumedriver().c_str(),
@@ -438,7 +453,8 @@ string DockerVolumeDriverIsolator::mount(
       em.volumename().c_str(),
       options.c_str());
 #else
-    Try<string> retcode = os::shell("%s %s%s %s%s %s",
+    Try<string> retcode = os::shell("%s %s %s%s %s%s %s",
+      em.dvdcli_path().c_str(),
       DVDCLI_MOUNT_CMD,
       VOL_DRIVER_CMD_OPTION,
       em.volumedriver().c_str(),
@@ -448,30 +464,30 @@ string DockerVolumeDriverIsolator::mount(
 #endif
 
     if (retcode.isError()) {
-      LOG(ERROR) << DVDCLI_MOUNT_CMD << " failed to execute on "
-                 << callerLabelForLogging
+      LOG(ERROR) << em.dvdcli_path()<< " " << DVDCLI_MOUNT_CMD
+                 << " failed to execute on " << callerLabelForLogging
                  << retcode.error();
     } else {
 #if MESOS_VERSION_INT != 0 && MESOS_VERSION_INT < 240
       if (retcode.get() != 0) {
-        LOG(ERROR) << DVDCLI_MOUNT_CMD << " returned errorcode "
-                   << retcode.get();
+        LOG(ERROR) << em.dvdcli_path() << " " << DVDCLI_MOUNT_CMD
+                   << " returned errorcode " << retcode.get();
       } else if (strings::trim(cmdOut.str()).empty()) {
-        LOG(ERROR) << DVDCLI_MOUNT_CMD
+        LOG(ERROR) << em.dvdcli_path() << " " << DVDCLI_MOUNT_CMD
                    << " returned an empty mountpoint name";
       } else {
         mountpoint = strings::trim(cmdOut.str());
-        LOG(INFO) << DVDCLI_MOUNT_CMD << " returned mountpoint:"
-                  << mountpoint;
+        LOG(INFO) << em.dvdcli_path() << " " << DVDCLI_MOUNT_CMD
+                  << " returned mountpoint:" << mountpoint;
       }
 #else
       if (strings::trim(retcode.get()).empty()) {
-        LOG(ERROR) << DVDCLI_MOUNT_CMD
+        LOG(ERROR) << em.dvdcli_path() << " " << DVDCLI_MOUNT_CMD
                    << " returned an empty mountpoint name";
       } else {
         mountpoint = strings::trim(retcode.get());
-        LOG(INFO) << DVDCLI_MOUNT_CMD << " returned mountpoint:"
-                  << mountpoint;
+        LOG(INFO) << em.dvdcli_path() << " " << DVDCLI_MOUNT_CMD
+                  << " returned mountpoint:" << mountpoint;
       }
 #endif
     }
@@ -525,7 +541,6 @@ bool DockerVolumeDriverIsolator::parseEnvVar(
             << envvar.value() << ") parsed from environment";
   return true;
 }
-
 
 Failure DockerVolumeDriverIsolator::revertMountlist(
     const char*                                      operation,
@@ -619,6 +634,7 @@ Future<Option<ContainerLaunchInfo>> DockerVolumeDriverIsolator::prepare(
   envvararray volumeNames;
   envvararray mountOptions;
   envvararray containerPaths;
+  envvararray dvdcliPaths;
 
   // Iterate through the environment variables,
   // looking for the ones we need.
@@ -627,7 +643,7 @@ Future<Option<ContainerLaunchInfo>> DockerVolumeDriverIsolator::prepare(
 
     if (strings::startsWith(variable.name(), VOL_NAME_ENV_VAR_NAME)) {
       if (!parseEnvVar(variable, VOL_NAME_ENV_VAR_NAME, volumeNames, true)) {
-        return Failure("prepare() failed due to illegal environment variable");
+        return Failure("prepare() failed due to illegal VOL_NAME_ENV_VAR_NAME");
       }
     } else if (strings::startsWith(variable.name(), VOL_DRIVER_ENV_VAR_NAME)) {
       if (!parseEnvVar(
@@ -635,11 +651,11 @@ Future<Option<ContainerLaunchInfo>> DockerVolumeDriverIsolator::prepare(
           VOL_DRIVER_ENV_VAR_NAME,
           deviceDriverNames,
           true)) {
-        return Failure("prepare() failed due to illegal environment variable");
+        return Failure("prepare() failed due to illegal VOL_DRIVER_ENV_VAR_NAME");
       }
     } else if (strings::startsWith(variable.name(), VOL_OPTS_ENV_VAR_NAME)) {
       if (!parseEnvVar(variable, VOL_OPTS_ENV_VAR_NAME, mountOptions, true)) {
-        return Failure("prepare() failed due to illegal environment variable");
+        return Failure("prepare() failed due to illegal VOL_OPTS_ENV_VAR_NAME");
       }
     } else if (strings::startsWith(variable.name(), VOL_CPATH_ENV_VAR_NAME)) {
       if (!parseEnvVar(
@@ -647,7 +663,11 @@ Future<Option<ContainerLaunchInfo>> DockerVolumeDriverIsolator::prepare(
           VOL_CPATH_ENV_VAR_NAME,
           containerPaths,
           false)) {
-        return Failure("prepare() failed due to illegal environment variable");
+        return Failure("prepare() failed due to illegal VOL_CPATH_ENV_VAR_NAME");
+      }
+    } else if (strings::startsWith(variable.name(), VOL_DVDCLI_ENV_VAR_NAME)) {
+      if (!parseEnvVar(variable, VOL_DVDCLI_ENV_VAR_NAME, dvdcliPaths, false)) {
+        return Failure("prepare() failed due to illegal VOL_DVDCLI_ENV_VAR_NAME");
       }
     }
   }
@@ -675,6 +695,9 @@ Future<Option<ContainerLaunchInfo>> DockerVolumeDriverIsolator::prepare(
     if (deviceDriverNames[i].empty()) {
       deviceDriverNames[i] = VOL_DRIVER_DEFAULT;
     }
+    if (dvdcliPaths[i].empty()) {
+      dvdcliPaths[i] = DEFAULT_DVDCLI_BIN;
+    }
 
     // TODO consider not filling container path if it is empty.
     // Empty container path would mean leaving do not engage isolation on mount
@@ -697,6 +720,7 @@ Future<Option<ContainerLaunchInfo>> DockerVolumeDriverIsolator::prepare(
                .setVolumeName(volumeNames[i])
                .setOptions(mountOptions[i])
                .setContainerPath(containerPaths[i])
+               .setDvdcliPath(dvdcliPaths[i])
                .build()
       );
 

--- a/isolator/isolator/docker_volume_driver_isolator.hpp
+++ b/isolator/isolator/docker_volume_driver_isolator.hpp
@@ -43,8 +43,8 @@ namespace mesos {
 namespace slave {
 
 static constexpr char REXRAY_MOUNT_PREFIX[]       = "/var/lib/rexray/volumes/";
-static constexpr char DVDCLI_MOUNT_CMD[]          = "/usr/bin/dvdcli mount";
-static constexpr char DVDCLI_UNMOUNT_CMD[]        = "/usr/bin/dvdcli unmount";
+static constexpr char DVDCLI_MOUNT_CMD[]          = "mount";
+static constexpr char DVDCLI_UNMOUNT_CMD[]        = "unmount";
 
 static constexpr char VOL_NAME_CMD_OPTION[]       = "--volumename=";
 static constexpr char VOL_DRIVER_CMD_OPTION[]     = "--volumedriver=";
@@ -55,10 +55,12 @@ static constexpr char VOL_NAME_ENV_VAR_NAME[]     = "DVDI_VOLUME_NAME";
 static constexpr char VOL_DRIVER_ENV_VAR_NAME[]   = "DVDI_VOLUME_DRIVER";
 static constexpr char VOL_OPTS_ENV_VAR_NAME[]     = "DVDI_VOLUME_OPTS";
 static constexpr char VOL_CPATH_ENV_VAR_NAME[]    = "DVDI_VOLUME_CONTAINERPATH";
+static constexpr char VOL_DVDCLI_ENV_VAR_NAME[]   = "DVDI_VOLUME_DVDCLI";
 
 static constexpr char DVDI_MOUNTLIST_FILENAME[]   = "dvdimounts.pb";
 static constexpr char DVDI_WORKDIR_PARAM_NAME[]   = "work_dir";
 static constexpr char DEFAULT_WORKING_DIR[]       = "/tmp/mesos";
+static constexpr char DEFAULT_DVDCLI_BIN[]        = "/usr/bin/dvdcli";
 
 #if MESOS_VERSION_INT != 0 && MESOS_VERSION_INT < 240
 class DockerVolumeDriverIsolator: public mesos::slave::IsolatorProcess

--- a/isolator/isolator/interface.hpp
+++ b/isolator/isolator/interface.hpp
@@ -14,9 +14,9 @@ private:
   std::string volumeDriver;
   std::string volumeName;
   std::string mountPoint;
-  //hashmap<std::string, std::string> opts; //TODO revisit this later
   std::string options;
   std::string containerPath;
+  std::string dvdcliPath;
 
 public:
   // create Builder with default values assigned
@@ -45,23 +45,19 @@ public:
     this->mountPoint = mountPoint;
     return *this;
   }
-  //TODO revisit this later
-  /*
-  Builder& addOption( const std::string key, const std::string value )
-  {
-    this->opts.put( key, value );
-    return *this;
-  }
-  */
   Builder& setOptions( const std::string options )
   {
     this->options = options;
     return *this;
   }
-
   Builder& setContainerPath( const std::string _containerPath )
   {
     this->containerPath = _containerPath;
+    return *this;
+  }
+  Builder& setDvdcliPath( const std::string _dvdcliPath )
+  {
+    this->dvdcliPath = _dvdcliPath;
     return *this;
   }
 
@@ -74,17 +70,7 @@ public:
     mount->set_mountpoint(mountPoint);
     mount->set_options(options);
     mount->set_container_path(containerPath);
-
-    //TODO revisit this later
-    /*
-    for (const auto &opt : opts)
-    {
-      ExternalMount_ExternalMountOption* newopt = mount->add_option();
-      newopt->set_key(opt.first);
-      newopt->set_key(opt.second);
-    }
-    */
-
+    mount->set_dvdcli_path(dvdcliPath);
     return mount;
   }
 };

--- a/isolator/isolator/interface.proto
+++ b/isolator/isolator/interface.proto
@@ -12,10 +12,14 @@ message ExternalMount {
   // This is chosen by the volume driver at run time and not configurable.
   optional string mountpoint = 4;
 
+  //mount options... filesystem type (ext4), etc
   optional string options = 5;
 
   // Absolute path pointing to a directory or file in the container.
   optional string container_path = 6;
+
+  //the fully qualified path to the dvdcli binary path
+  optional string dvdcli_path = 7;
 }
 
 // Our address book file is just one of these.


### PR DESCRIPTION
Changes:
1) The user-defined specified DVDCLI is done by setting the ENV parameter DVDI_VOLUME_DVDCLI. By default, we use /usr/bin/dvdcli
2) Deleted some unreferenced code
3) Delete some old protobuf stuff marked TODO that we will no longer get to.
