### PR TITLE
Change the location of the isolators checkpoint file.

### DIFF
--- a/isolator/isolator/docker_volume_driver_isolator.cpp
+++ b/isolator/isolator/docker_volume_driver_isolator.cpp
@@ -120,8 +120,7 @@ Try<Isolator*> DockerVolumeDriverIsolator::create(
     }
   }
 
-  mountPbFilename = path::join(getMetaRootDir(mesosWorkingDir),
-                                 DVDI_MOUNTLIST_FILENAME);
+  mountPbFilename = path::join(DVDI_MOUNTLIST_PATH, DVDI_MOUNTLIST_FILENAME);
   LOG(INFO) << "using " << mountPbFilename;
 
 #if MESOS_VERSION_INT != 0 && MESOS_VERSION_INT < 240

--- a/isolator/isolator/docker_volume_driver_isolator.hpp
+++ b/isolator/isolator/docker_volume_driver_isolator.hpp
@@ -42,6 +42,7 @@ using namespace emccode::isolator::mount;
 namespace mesos {
 namespace slave {
 
+static constexpr char DVDI_MOUNTLIST_PATH[]       = "/var/run/mesos/isolators/mesos-module-dvdi/";
 static constexpr char REXRAY_MOUNT_PREFIX[]       = "/var/lib/rexray/volumes/";
 static constexpr char DVDCLI_MOUNT_CMD[]          = "mount";
 static constexpr char DVDCLI_UNMOUNT_CMD[]        = "unmount";


### PR DESCRIPTION
Currently the checkpoint info is stored at:
/tmp/mesos/meta/dvdimounts.pb

We will be moving to:
/var/run/mesos/isolators/mesos-module-dvdi/dvdimounts.pb

Unless anyone has any objections.
