### PR TITLE
Add explicit create feature from DVDCLI

### DIFF
--- a/isolator/isolator/docker_volume_driver_isolator.hpp
+++ b/isolator/isolator/docker_volume_driver_isolator.hpp
@@ -57,6 +57,7 @@ static constexpr char VOL_DRIVER_ENV_VAR_NAME[]   = "DVDI_VOLUME_DRIVER";
 static constexpr char VOL_OPTS_ENV_VAR_NAME[]     = "DVDI_VOLUME_OPTS";
 static constexpr char VOL_CPATH_ENV_VAR_NAME[]    = "DVDI_VOLUME_CONTAINERPATH";
 static constexpr char VOL_DVDCLI_ENV_VAR_NAME[]   = "DVDI_VOLUME_DVDCLI";
+static constexpr char VOL_EXPLICIT_ENV_VAR_NAME[]  = "DVDI_VOLUME_EXPLICITCREATE";
 
 static constexpr char DVDI_MOUNTLIST_FILENAME[]   = "dvdimounts.pb";
 static constexpr char DVDI_WORKDIR_PARAM_NAME[]   = "work_dir";

--- a/isolator/isolator/interface.hpp
+++ b/isolator/isolator/interface.hpp
@@ -17,6 +17,7 @@ private:
   std::string options;
   std::string containerPath;
   std::string dvdcliPath;
+  bool        explicitCreate;
 
 public:
   // create Builder with default values assigned
@@ -60,6 +61,11 @@ public:
     this->dvdcliPath = _dvdcliPath;
     return *this;
   }
+  Builder& setExplicitCreate( const bool _explicitCreate )
+  {
+    this->explicitCreate = _explicitCreate;
+    return *this;
+  }
 
   ExternalMount* build()
   {
@@ -71,6 +77,7 @@ public:
     mount->set_options(options);
     mount->set_container_path(containerPath);
     mount->set_dvdcli_path(dvdcliPath);
+    mount->set_explicit_create(explicitCreate);
     return mount;
   }
 };

--- a/isolator/isolator/interface.proto
+++ b/isolator/isolator/interface.proto
@@ -20,6 +20,9 @@ message ExternalMount {
 
   //the fully qualified path to the dvdcli binary path
   optional string dvdcli_path = 7;
+
+  //create the volume explicitly
+  optional bool explicit_create = 8;
 }
 
 // Our address book file is just one of these.


### PR DESCRIPTION
Addresses issue https://github.com/emccode/mesos-module-dvdi/issues/97 created by feature enhancement in DVDCLI PR https://github.com/emccode/dvdcli/pull/20.

Adds new ENV variable called DVDI_VOLUME_EXPLICITCREATE that you can set to true to require the volume be created ahead of time. If the volume doesnt exist, the mount fails.
