### PR TITLE
Handle the case when the recover state is empty in 0.28.2

### DIFF
--- a/isolator/isolator/docker_volume_driver_isolator.cpp
+++ b/isolator/isolator/docker_volume_driver_isolator.cpp
@@ -177,6 +177,10 @@ Future<Nothing> DockerVolumeDriverIsolator::recover(
   LOG(INFO) << "dvdicheckpoint::recover() called";
   Result<State> resultState =
     mesos::internal::slave::state::recover(mesosWorkingDir, true);
+  if (resultState.isNone()) {
+    LOG(INFO) << "dvdicheckpoint::recover(): recover state is NONE";
+    return Nothing();
+  }
 
   State state = resultState.get();
   LOG(INFO) << "dvdicheckpoint::recover() returned: " << state.errors;


### PR DESCRIPTION
This addresses the issue https://github.com/emccode/mesos-module-dvdi/issues/107

Previous to 0.28.2 the linux FS isolator is being called before ours on recover. This yields a valid checkpoint, it looks like the order has changed in 0.28.2 leading to the checkpoint directory not being there in the following cases;
- fresh install where the isolator has been installed but the agent has never started before
- using a non-default working directory
